### PR TITLE
Remove RaftLib submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ __pycache__/
 build/
 **/*.avf
 **/*.db
-**/3p/**

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/RaftLib"]
-	path = external/RaftLib
-	url = https://github.com/RaftLib/RaftLib.git


### PR DESCRIPTION
Building RaftLib as a submodule to SimDB is proving difficult -- trying again with clone/install workflow.