### PR TITLE
Move AppManager::getEnabledApps_ to a .cpp file to prevent multiple definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS_DEBUG "-U_FORTIFY_SOURCE -O0 -g3")
 
 project(simdb LANGUAGES CXX VERSION 4.0.0)
-add_library(simdb INTERFACE)
+add_library(simdb src/AppManager.cpp)
 add_library(SimDB::simdb ALIAS simdb)
 
 find_package(SQLite3 3.19 REQUIRED)
@@ -19,13 +19,15 @@ set(SIMDB_BASE ${CMAKE_CURRENT_SOURCE_DIR})
 option(SIMDB_PEDANTIC "Enable build with -Wall -Wextra -Werror" ON)
 
 if(SIMDB_PEDANTIC)
-    target_compile_options(simdb INTERFACE
+    target_compile_options(simdb PUBLIC
         $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Werror>
         $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Werror>
     )
 endif()
 
-target_include_directories(simdb INTERFACE
+target_compile_options(simdb PRIVATE -fPIC)
+
+target_include_directories(simdb PUBLIC
     $<BUILD_INTERFACE:${SIMDB_BASE}/include>
     $<INSTALL_INTERFACE:include>
 )
@@ -75,6 +77,12 @@ install(
         ${CMAKE_CURRENT_BINARY_DIR}/SimDBConfig.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/SimDBConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SimDB
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/libsimdb.a
+    DESTINATION lib
 )
 
 install(

--- a/include/simdb/apps/AppManager.hpp
+++ b/include/simdb/apps/AppManager.hpp
@@ -631,7 +631,7 @@ private:
     /// Enabled apps (may or may not be instantiated).
     /// Key is the App's NAME static member.
     /// Value is the number of instances to create.
-    static std::map<std::string, size_t> & getEnabledApps_();
+    static std::map<std::string, size_t>& getEnabledApps_();
 
     /// Associated database.
     DatabaseManager* db_mgr_ = nullptr;

--- a/include/simdb/apps/AppManager.hpp
+++ b/include/simdb/apps/AppManager.hpp
@@ -631,11 +631,7 @@ private:
     /// Enabled apps (may or may not be instantiated).
     /// Key is the App's NAME static member.
     /// Value is the number of instances to create.
-    static std::map<std::string, size_t>& getEnabledApps_()
-    {
-        static std::map<std::string, size_t> enabled_apps;
-        return enabled_apps;
-    }
+    static std::map<std::string, size_t> & getEnabledApps_();
 
     /// Associated database.
     DatabaseManager* db_mgr_ = nullptr;

--- a/src/AppManager.cpp
+++ b/src/AppManager.cpp
@@ -1,0 +1,10 @@
+#include "simdb/apps/AppManager.hpp"
+
+namespace simdb
+{
+    std::map<std::string, size_t> & AppManager::getEnabledApps_()
+    {
+        static std::map<std::string, size_t> enabled_apps;
+        return enabled_apps;
+    }
+}

--- a/src/AppManager.cpp
+++ b/src/AppManager.cpp
@@ -1,10 +1,9 @@
 #include "simdb/apps/AppManager.hpp"
 
-namespace simdb
+namespace simdb {
+std::map<std::string, size_t>& AppManager::getEnabledApps_()
 {
-    std::map<std::string, size_t> & AppManager::getEnabledApps_()
-    {
-        static std::map<std::string, size_t> enabled_apps;
-        return enabled_apps;
-    }
+    static std::map<std::string, size_t> enabled_apps;
+    return enabled_apps;
 }
+} // namespace simdb


### PR DESCRIPTION
I ran into an issue trying to compile our internal simulator with clang and link it against a Sparta + SimDB compiled with GCC. Clang was instantiating its own instance of `AppManager::getEnabledApps_` because it was present in the header and not linking against the instance in `libsparta.a`.

It seems that the singleton pattern requires the static instance to live in a single translation unit to guarantee that it works correctly across linkers.

I threw this together quickly, so let me know if the CMake config needs any changes.