### PR TITLE
Install Argos runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,18 @@ install(
     DESTINATION include
 )
 
+install(
+    DIRECTORY python/argos/
+    DESTINATION bin/argos_runtime
+    FILES_MATCHING
+    PATTERN "*.py"
+)
+
+install(
+    PROGRAMS python/argos/argos
+    DESTINATION bin
+)
+
 install(TARGETS simdb
     EXPORT SimDBTargets
 )

--- a/python/argos/argos
+++ b/python/argos/argos
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "${SCRIPT_DIR}/argos_runtime/argos.py" "$@"


### PR DESCRIPTION
This will trigger map_v3.0.1 since v3.0.0 is already tagged. Once installed, the new command is:

`argos --database path/to/file.db`

As the `argos` wrapper is in the bin directory.